### PR TITLE
Update LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2021-2024 RCMgames, joshua-8
+Copyright (c) 2024 PNW Assistive Technology and Joshua Phelps
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Like the other PNW-AT repositories I'm proposing that we use the MIT license but I'd be happy with any other permissive license.

This specific repository is a bit trickier since it is based on the MIT licensed RCMGames/RCMv2 template. We need to keep that MIT license, but for the new code specific to this repository I think we can either [add PNW-AT to it](https://gist.github.com/fbaierl/1d740a7925a6e0e608824eb27a429370) or add a second compatible license to cover PNW-AT's work.